### PR TITLE
Update GetBatteryState

### DIFF
--- a/qrb_ros_robot_base_msgs/CMakeLists.txt
+++ b/qrb_ros_robot_base_msgs/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetControlMode.srv"
@@ -27,12 +28,13 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/Rotate.srv"
   "srv/SetMotionMode.srv"
   "srv/EmergencyCmd.srv"
+  "srv/GetBatteryState.srv"
   "msg/Stop.msg"
-  "msg/GetBatteryState.msg"
   "msg/ChargerCmd.msg"
   "msg/Error.msg"
   "msg/Exception.msg"
   DEPENDENCIES std_msgs
+  DEPENDENCIES sensor_msgs
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/qrb_ros_robot_base_msgs/package.xml
+++ b/qrb_ros_robot_base_msgs/package.xml
@@ -15,6 +15,7 @@
   <test_depend>ament_lint_common</test_depend>
 
   <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/qrb_ros_robot_base_msgs/srv/GetBatteryState.srv
+++ b/qrb_ros_robot_base_msgs/srv/GetBatteryState.srv
@@ -1,2 +1,5 @@
 # Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
+
+---
+sensor_msgs/BatteryState battery_state


### PR DESCRIPTION
When requesting battery status using get_battery_state topic, the
status is published via the /battery topic. This notice other
subscribers, who did not request the battery status, which is
an unreasonable design.

We want only the requester to receive the updated battery status.
Therefore, changing get_battery_state from a topic to a service.